### PR TITLE
feat(webhook): add github validation webhook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
-sudo: false
+sudo: required
 language: go
 go:
 - 1.9
 - tip
+
+services:
+  - docker
+
+env:
+- CGO_ENABLED=1
 
 before_install:
 - go get golang.org/x/tools/cmd/cover
@@ -18,3 +24,16 @@ script:
 - go test -race ./...
 - go build
 - ./changelog
+- docker build -t skuid/changelog .
+
+after_success:
+   - if [ ! -z "$TRAVIS_TAG" ] && [ "$TRAVIS_GO_VERSION" == "1.9" ]; then
+     docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD quay.io
+     docker tag skuid/changelog quay.io/skuid/changelog:$TRAVIS_TAG;
+     docker push quay.io/skuid/changelog:$TRAVIS_TAG;
+     fi
+   - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_GO_VERSION" == "1.9" ]; then
+     docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD quay.io
+     docker tag skuid/changelog quay.io/skuid/changelog:master;
+     docker push quay.io/skuid/changelog:master;
+     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.6
+LABEL maintainer=devops@skuid.com
+EXPOSE 3000
+
+ADD changelog /usr/local/bin/
+ENTRYPOINT [ "changelog" ]
+CMD ["serve"]

--- a/README.md
+++ b/README.md
@@ -92,11 +92,21 @@ order. Any non-specified sections will be appended to the end alphabetically.
 Any sections that don't exist will be discarded. The "Unknown" section is
 always last.
 
+## Build Status Updates
+
+`changelog` can also be used to validate commits on a Pull Request to ensure that nothing is merged that does not meet your criteria. To do this, run
+
+```
+$ changelog serve --provider github --secret {your-webhook-secret} --token {your-api-token}
+```
+
+This will expose a webhook for Github Pull Request events that will update the build status every time there is an update.
+
+
 ## Roadmap
 
 - [ ] Flesh out README
 - [ ] Add a commit validation pre-commit hook command
-- [ ] Add a web service for Github status checking (ensuring commits are properly formatted)
 - [ ] Add a BitBucket Querier
 
 ## License

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/skuid/changelog/webhooks/github"
+	"github.com/skuid/spec"
+	"github.com/skuid/spec/lifecycle"
+	_ "github.com/skuid/spec/metrics"
+	"github.com/skuid/spec/middlewares"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+)
+
+// serveCmd represents the serve command
+var serveCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Serve a webhook endpoint for PR validation",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		l, _ := spec.NewStandardLogger()
+		zap.ReplaceGlobals(l)
+		var webhookHandler func(http.ResponseWriter, *http.Request)
+
+		switch viper.GetString("provider") {
+		case "github":
+			webhookHandler = github.GithubWebhook(viper.GetString("secret"), viper.GetString("token"))
+		default:
+			zap.L().Fatal(
+				fmt.Sprintf("webhook for provider %s isn't supported", viper.GetString("provider")),
+				zap.String("provider", viper.GetString("provider")),
+			)
+		}
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/webhook", webhookHandler)
+
+		handler := middlewares.Apply(
+			mux,
+			middlewares.InstrumentRoute(),
+			middlewares.Logging(),
+		)
+
+		internalMux := http.NewServeMux()
+		internalMux.Handle("/", handler)
+		internalMux.Handle("/metrics", promhttp.Handler())
+		internalMux.HandleFunc("/live", lifecycle.LivenessHandler)
+		internalMux.HandleFunc("/ready", lifecycle.ReadinessHandler)
+
+		server := &http.Server{
+			Addr:    fmt.Sprintf(":%d", viper.GetInt("port")),
+			Handler: internalMux,
+		}
+		lifecycle.ShutdownOnTerm(server)
+
+		zap.L().Info("starting changelog webhook server", zap.Int("port", viper.GetInt("port")))
+		if err := server.ListenAndServe(); err != http.ErrServerClosed {
+			zap.L().Fatal(err.Error())
+		}
+
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(serveCmd)
+
+	serveCmd.Flags().StringP("secret", "s", "", "webhook secret")
+	serveCmd.Flags().IntP("port", "n", 3000, "webhook server port")
+	viper.BindPFlags(serveCmd.Flags())
+}

--- a/webhooks/github/webhook.go
+++ b/webhooks/github/webhook.go
@@ -1,0 +1,189 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/google/go-github/github"
+	"github.com/skuid/changelog/src/changelog"
+	"github.com/skuid/changelog/webhooks"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+)
+
+const StatusFailure = "failure"
+const StatusPending = "pending"
+const StatusSuccess = "success"
+const StatusError = "error"
+
+type githubWebhookHelper struct {
+	*github.Client
+}
+
+func newGithubWebhookHelper(apiToken string) *githubWebhookHelper {
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: apiToken},
+	)
+	client := github.NewClient(oauth2.NewClient(ctx, ts))
+	return &githubWebhookHelper{client}
+}
+
+func (client *githubWebhookHelper) getPrCommits(event *github.PullRequestEvent, apiToken string) (changelog.Commits, error) {
+	// list the commits on the pull request
+	prCommits, _, err := client.PullRequests.ListCommits(
+		context.Background(),
+		event.Repo.Owner.GetLogin(),
+		event.Repo.GetName(),
+		event.PullRequest.GetNumber(),
+		&github.ListOptions{},
+	)
+	if err != nil {
+		return nil, err
+	}
+	// format them properly
+	commits := changelog.Commits{}
+	for _, c := range prCommits {
+		commit := changelog.NewCommit(c.GetSHA(), c.Commit.GetMessage())
+		if commit == nil {
+			continue
+		}
+		commits = append(commits, *commit)
+	}
+	return commits, nil
+}
+
+func (client *githubWebhookHelper) updateRepoStatus(repo *github.Repository, sha, state string) error {
+
+	var description string
+	switch state {
+	case StatusFailure:
+		description = "commit was improperly formatted"
+	case StatusSuccess:
+		description = "commit looks good"
+	case StatusPending:
+		description = "beginning commit format validation"
+	case StatusError:
+		description = "there was a problem validating commit format"
+	default:
+		return fmt.Errorf("repo status state %s is invalid", state)
+	}
+	creating := &github.RepoStatus{
+		State:       github.String(state),
+		Description: github.String(description),
+		Context:     github.String(webhooks.WebhookContextPullRequest),
+	}
+	_, _, err := client.Repositories.CreateStatus(
+		context.Background(),
+		repo.Owner.GetLogin(),
+		repo.GetName(),
+		sha,
+		creating,
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func handlePullRequestEvent(event *github.PullRequestEvent, apiToken string) {
+
+	eventAction := event.GetAction()
+	// only handle these specific actions
+	if eventAction != "opened" && eventAction != "repoened" && eventAction != "synchronize" {
+		return
+	}
+	client := newGithubWebhookHelper(apiToken)
+	commits, err := client.getPrCommits(event, apiToken)
+
+	if err != nil {
+		zap.L().Error(err.Error())
+		return
+	}
+
+	pullRequstNumber := event.PullRequest.GetNumber()
+	lastCommit := commits[len(commits)-1]
+	buildStatusSha := lastCommit.Hash
+
+	zap.L().Info("validating commit format for pull request", zap.Int("pull_request", pullRequstNumber))
+	err = client.updateRepoStatus(event.Repo, buildStatusSha, StatusPending)
+	if err != nil {
+		zap.L().Error(err.Error())
+		return
+	}
+
+	iviper := viper.New()
+	iviper.SetConfigType("toml")
+	querier := changelog.NewGithubQuerier(event.Repo.GetHTMLURL(), apiToken)
+
+	if config, err := querier.GetConfig(); err == nil {
+		iviper.ReadConfig(config)
+	} else {
+		zap.L().Warn(err.Error())
+	}
+
+	sectionAliasMap := changelog.MergeSectionAliasMaps(
+		changelog.NewSectionAliasMap(),
+		iviper.GetStringMapStringSlice("sections"),
+	)
+
+	commits = changelog.FilterCommits(
+		commits,
+		sectionAliasMap.Grep(),
+		false,
+	)
+	commits = changelog.FormatCommits(commits, sectionAliasMap)
+
+	if len(commits) < event.PullRequest.GetCommits() {
+		zap.L().Info("failed to validate commit format for pull request", zap.Int("pull_request", pullRequstNumber))
+		err := client.updateRepoStatus(event.Repo, buildStatusSha, StatusFailure)
+		if err != nil {
+			zap.L().Error(err.Error())
+		}
+		return
+	}
+
+	// everything looks good
+	err = client.updateRepoStatus(event.Repo, buildStatusSha, StatusSuccess)
+	if err != nil {
+		zap.L().Error(err.Error())
+		return
+	}
+	zap.L().Info("validated commit for pull request", zap.Int("pull_request", pullRequstNumber))
+	return
+}
+
+func GithubWebhook(secret, apiToken string) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		payload, err := github.ValidatePayload(r, []byte(secret))
+
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			io.WriteString(w, err.Error())
+			return
+		}
+
+		event, err := github.ParseWebHook(github.WebHookType(r), payload)
+
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			io.WriteString(w, err.Error())
+			return
+		}
+
+		if evt, ok := event.(*github.PullRequestEvent); ok {
+			go handlePullRequestEvent(evt, apiToken)
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+			io.WriteString(w, "unable to process event type")
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "{}")
+		return
+	}
+}

--- a/webhooks/webhook.go
+++ b/webhooks/webhook.go
@@ -1,0 +1,4 @@
+package webhooks
+
+const WebhookContextPullRequest = "changelog/pull-request"
+const WebhookContextPush = "changelog/push"


### PR DESCRIPTION
add support for building webhooks that can be used to validate and
update build status on a commit. right not it only supports pull
requests but it may be better to just support push since we only have 1
commit to deal with rather than N commits.