### PR TITLE
fix(cmd): fix --from-latest-tag

### DIFF
--- a/src/changelog/local_query.go
+++ b/src/changelog/local_query.go
@@ -122,7 +122,7 @@ func (l localQuerier) GetLatestTag() (string, error) {
 	if err != nil {
 		return "", errors.WithStack(err)
 	}
-	return out.String(), nil
+	return strings.TrimSpace(out.String()), nil
 }
 
 // GetLatestTagVersion returns the latest tag version


### PR DESCRIPTION
fixes the `--from-latest-tag` option. the command was returning the sha
with a new line.